### PR TITLE
Fix typo screen.md for Vue.js

### DIFF
--- a/content/intro-to-storybook/vue/en/screen.md
+++ b/content/intro-to-storybook/vue/en/screen.md
@@ -11,7 +11,7 @@ In this chapter, we continue to increase the sophistication by combining compone
 
 ## Nested container components
 
-As our app is straightforward, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Redux) in some layout and pulling a top-level `error` field out of the store (let's assume we'll set that field if we have some problem connecting to our server). Let's create a presentational `PureInboxScreen.vue` in your `src/components/` folder:
+As our app is straightforward, the screen we’ll build is pretty trivial, simply wrapping the `TaskList` component (which supplies its own data via Vuex) in some layout and pulling a top-level `error` field out of the store (let's assume we'll set that field if we have some problem connecting to our server). Let's create a presentational `PureInboxScreen.vue` in your `src/components/` folder:
 
 ```html:title=src/components/PureInboxScreen.vue
 <template>


### PR DESCRIPTION
It says Redux, but it's Vue.js, so it should be Vuex.